### PR TITLE
Allow match macro to accept instructions as a list

### DIFF
--- a/src/com/nytimes/querqy/commonrules.clj
+++ b/src/com/nytimes/querqy/commonrules.clj
@@ -95,7 +95,7 @@
   {:style/indent 1}
   ;; TODO LEFT/ RIGHT boundaries
   [head & tail]
-  `(match* '~head (vector ~@tail)))
+  `(match* '~head (flatten (vector ~@tail))))
 
 (defn- parse-string [string] (mapv #(LineParser/parseTerm %) (str/split string #"\s+")))
 

--- a/test/com/nytimes/querqy/commonrules_test.clj
+++ b/test/com/nytimes/querqy/commonrules_test.clj
@@ -1,7 +1,7 @@
 (ns com.nytimes.querqy.commonrules-test
   (:refer-clojure :exclude [filter])
   (:require
-    [clojure.test :refer [deftest is]]
+    [clojure.test :refer [deftest is testing]]
     [testit.core :refer [facts =>]]
     [clojure.datafy :refer [datafy]]
     [com.nytimes.querqy.commonrules :as r :refer [match synonym boost filter delete]]
@@ -84,3 +84,13 @@
     (rewrite dsl-rewriter "A10 B10") => (rewrite resource-rewriter "A10 B10")
     (rewrite dsl-rewriter "A11") => (rewrite resource-rewriter "A11")
     (rewrite dsl-rewriter "A11 B11") => (rewrite resource-rewriter "A11 B11")))
+
+(deftest match-inputs-test
+  (testing "match accepts instructions or a list of instructions"
+    (is (fn? (match "a"
+               (synonym "b"))))
+    (is (fn? (match "a"
+               [(synonym "b") (synonym "c")])))
+    (is (fn? (match "a"
+               [(synonym "b") (synonym "c")]
+               [(boost 2 "d") (boost 2 "e")])))))


### PR DESCRIPTION
This improves the ability to write custom instructions which are
compositions of other instructions. As an example, this change will let you write an instruction for pinning results in queries:

```clojure
(defn pin
  "Pin the given IDs to the top of the result set in the order given. Should only
  be used once within a given match rule."
  [& ids]
  (map-indexed
   (fn [idx id]
     (c/boost (- Float/MAX_VALUE idx) {:ids {:values [id]}}))
   ids))


;; Let's assume we have some special thanksgiving related content that editorial
;; wants highly promoted, the documents with IDs 12345 and 5678. Rather than
;; tweak scores or sprinkle boosts around our rule set, we can instead use our
;; new pin rule which makes clear the intent of the boost and serves as
;; documentation for what we're trying to achieve with this rule.
(def rules
  (c/rules-rewriter
   (c/match "thanksgiving"
     (pin "12345" "5678"))))


;;  We can now emit a query which pins results to the top.

(def opts {:match/fields ["headline"]})

(q/emit (q/rewrite rules "thanksgiving recipes") opts)

{:function_score
 {:query
  {:bool
   {:must [],
    :should
    [{:match {"headline" {:query "thanksgiving"}}}
     {:match {"headline" {:query "recipes"}}}],
    :must_not [],
    :filter []}},
  :functions
  [{:filter {:ids {:values ["5678"]}}, :weight 1.0E37}
   {:filter {:ids {:values ["12345"]}}, :weight 1.0E38}]}}

```